### PR TITLE
Redirect authenticated users from homepage to /dashboard

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,10 +1,18 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
 
 const isProtectedRoute = createRouteMatcher(["/dashboard(.*)"]);
 
 export default clerkMiddleware(async (auth, req) => {
   if (isProtectedRoute(req)) {
     await auth.protect();
+  }
+
+  const { userId } = await auth();
+
+  if (userId && req.nextUrl.pathname === "/") {
+    const dashboardUrl = new URL("/dashboard", req.url);
+    return NextResponse.redirect(dashboardUrl);
   }
 });
 


### PR DESCRIPTION
When a logged-in user visits the homepage (/), the Clerk middleware now redirects them to /dashboard automatically.